### PR TITLE
add new arguments for optional port clamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ console.log(toPort('example.com')) // returns 22019
 
 ## API
 
-#### `var port = toPort(value)`
+#### `var port = toPort(value, ?from, ?to)`
 
-Hash the given value to a valid port (`>= 1024 <= 65535`).
+Hash the given value to a valid port (`>= from <= to`).
 The same value will *always* hash to the same port but note that two different values might hash to the same port as well
+
+- `value` <string>
+- `from` <?number> (default: `1024`)
+- `to` <?number> (default: `65535`)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
 var hash = require('hash-index')
 
-module.exports = function (hostname) {
-  return hash(hostname, 65535 - 1024) + 1024
+module.exports = function (hostname, from, to) {
+  from = from || 1024
+  to = to || 65535
+
+  if (typeof from !== 'number' || typeof to !== 'number') {
+    throw new TypeError('"to" and "from" arguments must be valid numbers!')
+  }
+
+  if (from >= to) {
+    throw new RangeError('"to" must be greater or equal to than "from"')
+  }
+
+  if (from < 1024 || to > 65535) {
+    throw new RangeError('port numbers must be between 1024 and 65535')
+  }
+
+  return hash(hostname, to - from) + from
 }

--- a/test.js
+++ b/test.js
@@ -4,6 +4,8 @@ var toPort = require('./')
 tape('is consistent', function (t) {
   t.same(toPort('test.com'), toPort('test.com'))
   t.same(toPort('example.com'), toPort('example.com'))
+  t.same(toPort('example.com', 2000), toPort('example.com', 2000))
+  t.same(toPort('example.com', 2000, 3000), toPort('example.com', 2000, 3000))
   t.end()
 })
 
@@ -14,4 +16,13 @@ tape('is >=1024 <=65535', function (t) {
     t.ok(port >= 1024)
   }
   t.end()
+})
+
+tape('rejects invalid port choices', function(t) {
+    t.throws(function () { toPort('foo', 'not a number') }, /must be valid numbers/)
+    t.throws(function () { toPort('foo', 2000, 'not a number') }, /must be valid numbers/)
+    t.throws(function () { toPort('foo', 9001, 9000) }, /must be greater or equal to/)
+    t.throws(function () { toPort('foo', 1023, 9000) }, /must be between 1024 and 65535/)
+    t.throws(function () { toPort('foo', 1024, 65536) }, /must be between 1024 and 65535/)
+    t.end()
 })


### PR DESCRIPTION
Hi @mafintosh, thanks for this great library!

I have a use case that needs the port to stay within a certain range, to avoid colliding with other services persistently running on the same host.

Are you open to this CR? Should be a semver minor change :)

Thanks!